### PR TITLE
Fix Dialyzer warnings for GenStage modules

### DIFF
--- a/lib/elixir_dnstap/buffer_stage.ex
+++ b/lib/elixir_dnstap/buffer_stage.ex
@@ -57,7 +57,7 @@ defmodule ElixirDnstap.BufferStage do
   - `{:ok, pid}` - BufferStage started successfully
   - `{:error, reason}` - Failed to start
   """
-  @spec start_link(keyword()) :: GenStage.on_start()
+  @spec start_link(keyword()) :: GenServer.on_start()
   def start_link(opts \\ []) do
     {gen_stage_opts, init_opts} = Keyword.split(opts, [:name])
     GenStage.start_link(__MODULE__, init_opts, gen_stage_opts)

--- a/lib/elixir_dnstap/producer.ex
+++ b/lib/elixir_dnstap/producer.ex
@@ -59,7 +59,7 @@ defmodule ElixirDnstap.Producer do
   - `{:ok, pid}` - Producer started successfully
   - `{:error, reason}` - Failed to start
   """
-  @spec start_link(keyword()) :: GenStage.on_start()
+  @spec start_link(keyword()) :: GenServer.on_start()
   def start_link(opts \\ []) do
     {gen_stage_opts, init_opts} = Keyword.split(opts, [:name])
     GenStage.start_link(__MODULE__, init_opts, gen_stage_opts)

--- a/lib/elixir_dnstap/writer_consumer.ex
+++ b/lib/elixir_dnstap/writer_consumer.ex
@@ -63,7 +63,7 @@ defmodule ElixirDnstap.WriterConsumer do
   - `{:ok, pid}` - WriterConsumer started successfully
   - `{:error, reason}` - Failed to start
   """
-  @spec start_link(keyword()) :: GenStage.on_start()
+  @spec start_link(keyword()) :: GenServer.on_start()
   def start_link(opts) do
     {gen_stage_opts, init_opts} = Keyword.split(opts, [:name])
     GenStage.start_link(__MODULE__, init_opts, gen_stage_opts)


### PR DESCRIPTION
## Summary

This PR fixes all 3 Dialyzer warnings reported in Issue #6.

## Changes

Replace \`GenStage.on_start/0\` with \`GenServer.on_start/0\` in typespec annotations for \`start_link/1\` functions in:
- \`ElixirDnstap.BufferStage\`
- \`ElixirDnstap.Producer\`
- \`ElixirDnstap.WriterConsumer\`

## Root Cause

GenStage modules use \`GenServer.start_link/3\` internally, so the correct return type is \`GenServer.on_start/0\`, not \`GenStage.on_start/0\` (which doesn't exist in the GenStage typespec).

## Testing

- ✅ Dialyzer passes with 0 errors after the fix
- ✅ All tests pass (82 passing, 23 failures are pre-existing Issue #3)

## Notes

The 23 test failures are pre-existing and documented in Issue #3 (\`File.rm_rf!/1\` undefined function errors). They are not introduced by this change.

Closes #6