### PR TITLE
ci: add dependency update workflow with auto-merge

### DIFF
--- a/.github/workflows/dependency-update.yml
+++ b/.github/workflows/dependency-update.yml
@@ -5,6 +5,10 @@ on:
     - cron: '0 1 * * 1'
   workflow_dispatch:
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   dependency-update:
     uses: smkwlab/.github/.github/workflows/dependency-update.yml@v1


### PR DESCRIPTION
Add dependency-update reusable workflow with auto_merge enabled so weekly dependency PRs are automatically merged when tests pass.