### PR TITLE
fix: resolve Elixir 1.19 compilation warnings

### DIFF
--- a/lib/elixir_dnstap/writer/tcp.ex
+++ b/lib/elixir_dnstap/writer/tcp.ex
@@ -334,7 +334,7 @@ defmodule ElixirDnstap.TcpWriter do
   end
 
   @impl GenServer
-  def handle_info(:connect, state) do
+  def handle_info(:connect, %State{} = state) do
     case do_connect(state) do
       {:ok, socket} ->
         Logger.info("DNSTap TcpWriter connected: #{state.host}:#{state.port}")
@@ -360,7 +360,7 @@ defmodule ElixirDnstap.TcpWriter do
     end
   end
 
-  def handle_info(:reconnect, state) do
+  def handle_info(:reconnect, %State{} = state) do
     # Clear the timer reference and attempt reconnection
     new_state = %State{state | reconnect_timer: nil}
     send(self(), :connect)
@@ -586,7 +586,7 @@ defmodule ElixirDnstap.TcpWriter do
     schedule_reconnect(new_state)
   end
 
-  defp handle_disconnect(state) do
+  defp handle_disconnect(%State{} = state) do
     new_state = %State{state | status: :disconnected}
     schedule_reconnect(new_state)
   end
@@ -610,7 +610,7 @@ defmodule ElixirDnstap.TcpWriter do
     %State{state | status: :disconnected}
   end
 
-  defp schedule_reconnect(state) do
+  defp schedule_reconnect(%State{} = state) do
     interval = state.current_interval
     timer_ref = Process.send_after(self(), :reconnect, interval)
 

--- a/lib/elixir_dnstap/writer/unix_socket.ex
+++ b/lib/elixir_dnstap/writer/unix_socket.ex
@@ -283,7 +283,7 @@ defmodule ElixirDnstap.UnixSocketWriter do
   end
 
   @impl GenServer
-  def handle_info(:connect, state) do
+  def handle_info(:connect, %State{} = state) do
     case do_connect(state) do
       {:ok, socket} ->
         Logger.info("DNSTap UnixSocketWriter connected: #{state.path}")
@@ -307,7 +307,7 @@ defmodule ElixirDnstap.UnixSocketWriter do
     end
   end
 
-  def handle_info(:reconnect, state) do
+  def handle_info(:reconnect, %State{} = state) do
     # Clear the timer reference and attempt reconnection
     new_state = %State{state | reconnect_timer: nil}
     send(self(), :connect)
@@ -490,7 +490,7 @@ defmodule ElixirDnstap.UnixSocketWriter do
     schedule_reconnect(new_state)
   end
 
-  defp handle_disconnect(state) do
+  defp handle_disconnect(%State{} = state) do
     new_state = %State{state | status: :disconnected}
     schedule_reconnect(new_state)
   end
@@ -512,7 +512,7 @@ defmodule ElixirDnstap.UnixSocketWriter do
     %State{state | status: :disconnected}
   end
 
-  defp schedule_reconnect(state) do
+  defp schedule_reconnect(%State{} = state) do
     # Cancel existing timer if present and flush any pending :reconnect messages
     if state.reconnect_timer do
       case Process.cancel_timer(state.reconnect_timer) do

--- a/mix.exs
+++ b/mix.exs
@@ -21,17 +21,22 @@ defmodule ElixirDnstap.MixProject do
 
       # Test coverage
       test_coverage: [tool: ExCoveralls],
-      preferred_cli_env: [
-        coveralls: :test,
-        "coveralls.detail": :test,
-        "coveralls.html": :test
-      ],
 
       # Dialyzer
       dialyzer: [
         plt_file: {:no_warn, "priv/plts/dialyzer.plt"},
         plt_add_apps: [:mix],
         ignore_warnings: ".dialyzer_ignore.exs"
+      ]
+    ]
+  end
+
+  def cli do
+    [
+      preferred_envs: [
+        coveralls: :test,
+        "coveralls.detail": :test,
+        "coveralls.html": :test
       ]
     ]
   end


### PR DESCRIPTION
## Summary

Resolve Elixir 1.19 compilation warnings that cause CI failure with `--warnings-as-errors`.

Resolve #13

## Changes

### Struct update type warnings (8 locations)
- `lib/elixir_dnstap/writer/tcp.ex`: Add `%State{}` pattern match to `handle_info/2`, `handle_disconnect/1`, `schedule_reconnect/1`
- `lib/elixir_dnstap/writer/unix_socket.ex`: Same pattern applied to matching functions

### Deprecated `preferred_cli_env` in mix.exs
- Removed `preferred_cli_env` from `def project`
- Added `def cli` with `preferred_envs` (Elixir 1.19+ convention)

## Test plan
- [x] `mix compile --warnings-as-errors` passes with zero warnings
- [x] `mix format --check-formatted` passes
- [x] `mix test` — 23 pre-existing failures (unrelated `Writer.File` module issue), no new failures