### PR TITLE
docs(readme): add Quick Start section and fix Usage API signatures

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,47 @@
 
 DNSTap logging library for Elixir - capture and export DNS query/response data using the DNSTap protocol and Frame Streams format.
 
+## Quick Start
+
+```elixir
+# 1. mix.exs に依存追加
+def deps do
+  [{:elixir_dnstap, "~> 0.1.0"}]
+end
+```
+
+```elixir
+# 2. config/config.exs で出力先（最小例: ファイル出力）を設定
+config :elixir_dnstap,
+  enabled: true,
+  output: [type: :file, path: "log/dnstap.fstrm"]
+```
+
+```elixir
+# 3. Application の supervision tree に Supervisor を組み込み、
+#    DNSWorker などから DNS パケットを送る
+defmodule MyApp.Application do
+  use Application
+
+  def start(_type, _args) do
+    Supervisor.start_link([ElixirDnstap.Supervisor], strategy: :one_for_one, name: MyApp.Supervisor)
+  end
+end
+
+# Client query を log
+:ok =
+  ElixirDnstap.log_client_query(
+    query_packet,
+    {192, 168, 1, 100},  # client_addr
+    54_321,              # client_port
+    {127, 0, 0, 1},      # server_addr
+    5353,                # server_port
+    :udp
+  )
+```
+
+書き出された `log/dnstap.fstrm` は [`dnstap`](https://github.com/dnstap/golang-dnstap) コマンドや [dnscollector](https://github.com/dmachard/go-dnscollector) で読み出し可能。詳細は下記 [Reading DNSTap Files](#reading-dnstap-files) を参照。
+
 ## Features
 
 - 📦 **Frame Streams Protocol** - Full implementation of uni-directional and bi-directional Frame Streams
@@ -96,29 +137,36 @@ end
 
 ### Logging DNS Messages
 
+`log_client_query/6` takes positional arguments; `log_client_response/1` takes a keyword list that includes the original query packet plus the query timestamp captured at receive time.
+
 ```elixir
 # Log a DNS client query
-ElixirDnstap.log_client_query(
-  query_packet,
-  socket_family: :inet,
-  socket_protocol: :udp,
-  query_address: {127, 0, 0, 1},
-  query_port: 12345,
-  response_address: {8, 8, 8, 8},
-  response_port: 53
-)
+:ok =
+  ElixirDnstap.log_client_query(
+    query_packet,
+    {127, 0, 0, 1},  # client_addr
+    12_345,          # client_port
+    {8, 8, 8, 8},    # server_addr
+    53,              # server_port
+    :udp             # :udp | :tcp
+  )
 
 # Log a DNS client response
-ElixirDnstap.log_client_response(
-  response_packet,
-  socket_family: :inet,
-  socket_protocol: :udp,
-  query_address: {127, 0, 0, 1},
-  query_port: 12345,
-  response_address: {8, 8, 8, 8},
-  response_port: 53
-)
+:ok =
+  ElixirDnstap.log_client_response(
+    query_packet: query_packet,
+    response_packet: response_packet,
+    client_addr: {127, 0, 0, 1},
+    client_port: 12_345,
+    server_addr: {8, 8, 8, 8},
+    server_port: 53,
+    socket_protocol: :udp,
+    query_time_sec: query_time_sec,
+    query_time_nsec: query_time_nsec
+  )
 ```
+
+Both functions return `{:error, :producer_not_available}` if the supervision tree has not been started.
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -10,23 +10,23 @@ DNSTap logging library for Elixir - capture and export DNS query/response data u
 ## Quick Start
 
 ```elixir
-# 1. mix.exs に依存追加
+# 1. Add the dependency in mix.exs
 def deps do
   [{:elixir_dnstap, "~> 0.1.0"}]
 end
 ```
 
 ```elixir
-# 2. config/config.exs で出力先（最小例: ファイル出力）を設定
+# 2. In config/config.exs, pick an output (minimal example: file output)
 config :elixir_dnstap,
   enabled: true,
   output: [type: :file, path: "log/dnstap.fstrm"]
 ```
 
 ```elixir
-# 3. アプリ起動時、ElixirDnstap.Application が enabled? を見て
-#    Supervisor を自動起動するので、ホスト側は DNS パケット受信時に
-#    log_client_query/6 を呼ぶだけ
+# 3. ElixirDnstap.Application checks `enabled?` at boot and starts the
+#    supervisor automatically, so the host only has to call
+#    log_client_query/6 when a DNS packet arrives.
 :ok =
   ElixirDnstap.log_client_query(
     query_packet,
@@ -38,7 +38,7 @@ config :elixir_dnstap,
   )
 ```
 
-書き出された `log/dnstap.fstrm` は [`dnstap`](https://github.com/dnstap/golang-dnstap) コマンドや [dnscollector](https://github.com/dmachard/go-dnscollector) で読み出し可能。詳細は下記 [Reading DNSTap Files](#reading-dnstap-files) を参照。
+The resulting `log/dnstap.fstrm` can be read with the [`dnstap`](https://github.com/dnstap/golang-dnstap) command-line tool or [dnscollector](https://github.com/dmachard/go-dnscollector). See [Reading DNSTap Files](#reading-dnstap-files) below for details.
 
 ## Features
 
@@ -109,9 +109,9 @@ config :elixir_dnstap,
 
 ### Starting the DNSTap Pipeline
 
-`elixir_dnstap` is itself an OTP application (`mod: {ElixirDnstap.Application, []}` in `mix.exs`). When the host application starts, `ElixirDnstap.Application.start/2` runs automatically as part of dependency resolution and starts `ElixirDnstap.Supervisor` whenever `:elixir_dnstap, :enabled` is `true`. **No supervision-tree wiring on the host side is required for the normal case** — adding the dep and setting `enabled: true` is enough.
+`elixir_dnstap` is itself an OTP application (`mod: {ElixirDnstap.Application, []}` in `mix.exs`). When the host application starts, `ElixirDnstap.Application.start/2` runs automatically as part of dependency resolution and starts `ElixirDnstap.Supervisor` whenever `:elixir_dnstap, :enabled` is `true`. **No supervision-tree wiring on the host side is required** — adding the dep and setting `enabled: true` is enough.
 
-If you do need to start the pipeline yourself (for example, you set `enabled: false` to keep it off by default and want to enable it dynamically), call `Supervisor.start_link/2` with `ElixirDnstap.Supervisor` exactly once. Adding it to a host supervision tree on top of the auto-start would fail with `{:already_started, pid}`.
+The setting is consulted in two places: `ElixirDnstap.Application.start/2` decides whether to start `ElixirDnstap.Supervisor` at all, and `ElixirDnstap.Supervisor.init/1` decides whether to bring up the GenStage pipeline. Starting `ElixirDnstap.Supervisor` manually while `enabled` is still `false` therefore produces an empty supervision tree, and subsequent `log_client_query/6` calls return `{:error, :producer_not_available}`. To enable logging at runtime, set `enabled: true` (via `Application.put_env/3` or your release config) before the supervisor starts.
 
 ### Logging DNS Messages
 

--- a/README.md
+++ b/README.md
@@ -24,17 +24,9 @@ config :elixir_dnstap,
 ```
 
 ```elixir
-# 3. Application の supervision tree に Supervisor を組み込み、
-#    DNSWorker などから DNS パケットを送る
-defmodule MyApp.Application do
-  use Application
-
-  def start(_type, _args) do
-    Supervisor.start_link([ElixirDnstap.Supervisor], strategy: :one_for_one, name: MyApp.Supervisor)
-  end
-end
-
-# Client query を log
+# 3. アプリ起動時、ElixirDnstap.Application が enabled? を見て
+#    Supervisor を自動起動するので、ホスト側は DNS パケット受信時に
+#    log_client_query/6 を呼ぶだけ
 :ok =
   ElixirDnstap.log_client_query(
     query_packet,
@@ -117,23 +109,9 @@ config :elixir_dnstap,
 
 ### Starting the DNSTap Pipeline
 
-Add `ElixirDnstap.Supervisor` to your application's supervision tree:
+`elixir_dnstap` is itself an OTP application (`mod: {ElixirDnstap.Application, []}` in `mix.exs`). When the host application starts, `ElixirDnstap.Application.start/2` runs automatically as part of dependency resolution and starts `ElixirDnstap.Supervisor` whenever `:elixir_dnstap, :enabled` is `true`. **No supervision-tree wiring on the host side is required for the normal case** — adding the dep and setting `enabled: true` is enough.
 
-```elixir
-defmodule MyApp.Application do
-  use Application
-
-  def start(_type, _args) do
-    children = [
-      # ... other children
-      ElixirDnstap.Supervisor
-    ]
-
-    opts = [strategy: :one_for_one, name: MyApp.Supervisor]
-    Supervisor.start_link(children, opts)
-  end
-end
-```
+If you do need to start the pipeline yourself (for example, you set `enabled: false` to keep it off by default and want to enable it dynamically), call `Supervisor.start_link/2` with `ElixirDnstap.Supervisor` exactly once. Adding it to a host supervision tree on top of the auto-start would fail with `{:already_started, pid}`.
 
 ### Logging DNS Messages
 


### PR DESCRIPTION
## Summary

ecosystem CLAUDE.md TODO #3「各リポジトリ README に Quick Start を統一導入」の一環。本リポジトリは元から品質が高いため、**ゼロからの書き直しではなく Quick Start を独立セクションとして冒頭に追加**し、副次的に既存 Usage / 起動手順の不正確な記述を修正します。

## 変更内容

### 1. Quick Start セクション新設（タグライン直後）

3 ステップで導入完了する最小経路（英語、HexDocs 公開と整合）:

1. `mix.exs` に `{:elixir_dnstap, "~> 0.1.0"}` 追加
2. `config/config.exs` でファイル出力を設定（`enabled: true, output: [type: :file, path: "log/dnstap.fstrm"]`）
3. **host 側は何もせず**（`enabled: true` で `ElixirDnstap.Application` が `Supervisor` を自動起動）、DNS パケット受信時に `log_client_query/6` を呼ぶだけ

書き出されたフレームの読み出しツール（`dnstap` / dnscollector）への導線も明示。

### 2. 既存 Usage セクションの API 例修正

| 関数 | 旧 README | 実装 (`lib/elixir_dnstap.ex`) |
|---|---|---|
| `log_client_query/6` | keyword 引数 `socket_family:`, `query_address:`, `response_address:` （存在しないキー） | positional `(packet, client_addr, client_port, server_addr, server_port, :udp\|:tcp)` |
| `log_client_response/1` | `query_address:`/`response_address:` キー、`query_time_sec/nsec` 欠如 | `client_addr:`/`server_addr:`/`query_packet:`/`response_packet:`/`query_time_sec:`/`query_time_nsec:` 等 |

加えて両関数の `{:error, :producer_not_available}` 返却を明記。

### 3. "Starting the DNSTap Pipeline" セクション全面書き直し

旧記述は「host 側 supervision tree に `ElixirDnstap.Supervisor` を追加せよ」だったが、実装と矛盾していたため修正:

- **正解**: `elixir_dnstap` は `mod: {ElixirDnstap.Application, []}` で OTP application 化済み。`enabled: true` で `Application.start/2` が自動的に `ElixirDnstap.Supervisor` を起動するため、host 側 supervision tree への追加は **不要**（同名 supervisor 二重起動で `{:already_started, pid}` クラッシュ）
- 加えて `Supervisor.init/1` も `Config.enabled?()` を見て children を組み立てるため、runtime で動的有効化したい場合は **supervisor 起動前に `enabled: true` を set** する必要がある（`Application.put_env/3` or release config 経由）

## エコシステム整合性

[tdig README](https://github.com/smkwlab/tdig/blob/main/README.md) のフォーマット（タグライン → Quick Start → Features → 詳細）を踏襲。

## Copilot レビュー対応の記録

本 PR では Copilot が連続して有効な指摘を出してくれました（いずれも反映済み）:

1. **Quick Start 初版の supervision tree 二重起動バグ** (commit `f59d158`)
2. **dynamic-start 例の不正確性 + Quick Start の言語不整合** (commit `174df20`)
3. **PR description の古い手順記述の更新**（本コメント自体）

## Test plan
- [x] `mix test` 111 tests / 3 doctests / 0 failures
- [x] `mix credo --strict` 0 issues
- [x] `mix format --check-formatted` 通過
- [x] Lefthook pre-commit 全項目通過

resolve #28