### PR TITLE
ci: track shared elixir-ci workflow at @v1 instead of @v1.0.0

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -21,5 +21,5 @@ concurrency:
 
 jobs:
   ci:
-    uses: smkwlab/.github/.github/workflows/elixir-ci.yml@v1.0.0
+    uses: smkwlab/.github/.github/workflows/elixir-ci.yml@v1
     secrets: inherit


### PR DESCRIPTION
## 概要

共有再利用ワークフロー `smkwlab/.github/.github/workflows/elixir-ci.yml` の参照を `@v1.0.0` (pin) から `@v1` (movable tag) に変更する。

## 背景

他の caller リポジトリ（tenbin_dns / tdig / tenbin_ex / tenbin_cache）は `@v1` を参照しており、エコシステム共通の OTP/Elixir バージョン更新（[smkwlab/.github#65](https://github.com/smkwlab/.github/pull/65) で OTP 29.0.2 / Elixir 1.20.1 に更新）を `v1` タグの張り直しで一括反映している。

本リポのみ `@v1.0.0` を pin しているため、そのままでは共通更新が反映されない。`@v1` に揃えることで今後のバージョン更新を自動追従させる。

## 検証

- `actionlint .github/workflows/elixir.yml` green（exit 0）。
- 変更は workflow のタグ参照 1 行のみで Elixir コードには非干渉。
- ⚠️ 実反映の確認は `smkwlab/.github` 側で `v1` タグが新コミットへ張り直された後の fresh run で行う。
