### PR TITLE
docs: Mermaid-ize GenStage pipeline diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,18 +150,34 @@ Both functions return `{:error, :producer_not_available}` if the supervision tre
 
 ElixirDnstap uses a GenStage pipeline for efficient message processing:
 
+```mermaid
+graph LR
+  Host["Host app<br/>(log_client_query/6)"]
+  Producer["Producer<br/>(GenStage :producer)"]
+  BufferStage["BufferStage<br/>(GenStage :producer_consumer)"]
+  WriterConsumer["WriterConsumer<br/>(GenStage :consumer)"]
+  Writer["Writer.{File,TCP,UnixSocket}<br/>(GenServer)"]
+  Output["File / TCP / Unix socket"]
+
+  Producer --> BufferStage
+  BufferStage --> WriterConsumer
+  WriterConsumer --> Writer
+
+  Host -. "enqueue (GenStage.cast)" .-> Producer
+  WriterConsumer -. "write/1" .-> Writer
+  Writer -. "Frame Streams I/O" .-> Output
 ```
-DNS Messages → Producer → BufferStage → WriterConsumer → Writer (File/TCP/Unix Socket)
-                 ↓            ↓              ↓
-            Backpressure  Encoding    Frame Streams
-```
+
+Solid arrows (`-->`) are the GenStage subscription chain (downstream stage subscribes to upstream); dotted arrows are runtime relationships (message enqueue, write delegation, and I/O). All three GenStage stages plus the selected writer are started under `ElixirDnstap.Supervisor` (`:one_for_one`).
 
 ### Components
 
-- **Producer** - Receives DNS messages and manages backpressure
-- **BufferStage** - Encodes messages to Protocol Buffers and Frame Streams
-- **WriterConsumer** - Consumes encoded frames and writes to output
-- **Writers** - Handle specific output types (File, TCP, Unix Socket)
+- **Producer** (`:producer`) - Receives DNS messages from the host via `enqueue/2` (`GenStage.cast`) and manages demand-based backpressure with an internal queue.
+- **BufferStage** (`:producer_consumer`) - Encodes each message to a DNSTap **Protocol Buffers** payload via `ElixirDnstap.Encoder` (stateless transformation).
+- **WriterConsumer** (`:consumer`) - Delegates each encoded payload to the configured writer module via `writer_module.write/1`.
+- **Writer** (`Writer.File` / `Writer.TCP` / `Writer.UnixSocket`) - GenServers that wrap payloads in **Frame Streams** frames and perform the actual File / TCP / Unix-socket I/O.
+
+> Note: Protocol Buffers encoding happens in **BufferStage**, while **Frame Streams** framing is delegated to the **Writer** (see `ElixirDnstap.BufferStage`'s design note) — these are two distinct encoding steps, not one.
 
 ## Frame Streams Protocol
 


### PR DESCRIPTION
## 概要

エコシステム横断 TODO #5（アーキテクチャ図の Mermaid 化と一貫適用）の一環として、README の `## Architecture` セクションにある GenStage パイプラインの ASCII 図を Mermaid (`graph LR`) に変換しました。参照実装は tenbin_cache PR #106 です。

## コード照合の結果

README の既存記述を鵜呑みにせず `lib/` の実コードと照合しました。各ステージの実態:

- `Producer` = `{:producer, ...}`（`lib/elixir_dnstap/producer.ex`）— host が `enqueue/2`（`GenStage.cast`）で投入、demand ベースのバックプレッシャー + 内部キュー
- `BufferStage` = `{:producer_consumer, ...}`（`lib/elixir_dnstap/buffer_stage.ex`）— `ElixirDnstap.Encoder` で **Protocol Buffers** にエンコード（ステートレス変換）
- `WriterConsumer` = `{:consumer, ...}`（`lib/elixir_dnstap/writer_consumer.ex`）— `writer_module.write/1` に委譲
- `Writer.{File,TCP,UnixSocket}` = GenServer（`lib/elixir_dnstap/writer/`）— **Frame Streams** フレーミング（`FrameStreams.encode_data_frame`）と実 I/O
- 起動構成は `lib/elixir_dnstap/supervisor.ex` で確認（Producer → BufferStage → WriterConsumer + 選択された Writer を `:one_for_one` で起動）

### 既存 ASCII との差分（修正点）

既存 ASCII 図は 2 段目ラベルで `BufferStage → Encoding` / `WriterConsumer → Frame Streams` としており、**Frame Streams 段を WriterConsumer の下に誤配置**していました。実際には:

- **Protocol Buffers エンコードは BufferStage** で行う
- **Frame Streams フレーミングは Writer に委譲**される（`BufferStage` の moduledoc の Design Note: "Frame Streams encoding is delegated to the Writer ... to avoid double encoding"）

この 2 つは別個のエンコード段であることを Mermaid 化と同時に修正し、補足 note に明記しました。

## スタイル方針

- pipeline 系なので `graph LR`
- 実線 `-->` = GenStage の subscription chain（下流が上流を subscribe）
- 点線 `-. label .->` = ランタイム関係（host からの enqueue cast / `write/1` 委譲 / Frame Streams I/O）
- `classDef` 等の装飾は使わず構造の明快さを優先
- ノードラベルは `"名前<br/>(役割)"` 形式
- 図の直後に凡例・コンポーネント説明・補足 note を prose で併記

## 変更後の Mermaid

```mermaid
graph LR
  Host["Host app<br/>(log_client_query/6)"]
  Producer["Producer<br/>(GenStage :producer)"]
  BufferStage["BufferStage<br/>(GenStage :producer_consumer)"]
  WriterConsumer["WriterConsumer<br/>(GenStage :consumer)"]
  Writer["Writer.{File,TCP,UnixSocket}<br/>(GenServer)"]
  Output["File / TCP / Unix socket"]

  Producer --> BufferStage
  BufferStage --> WriterConsumer
  WriterConsumer --> Writer

  Host -. "enqueue (GenStage.cast)" .-> Producer
  WriterConsumer -. "write/1" .-> Writer
  Writer -. "Frame Streams I/O" .-> Output
```

## テスト

Lefthook（format / test / credo）全 green（114 tests passed, credo no issues）。docs のみの変更です。

`## Frame Streams Protocol` 配下の START→DATA→STOP 等の小図はスコープ外として変更していません。