### PR TITLE
Bound the producer queue with a high-water mark (#36)

### DIFF
--- a/lib/elixir_dnstap/producer.ex
+++ b/lib/elixir_dnstap/producer.ex
@@ -45,6 +45,7 @@ defmodule ElixirDnstap.Producer do
   @drop_log_interval 1_000
 
   defstruct queue: :queue.new(),
+            queue_len: 0,
             demand: 0,
             max_demand: 100,
             max_queue_size: @default_max_queue_size,
@@ -52,6 +53,7 @@ defmodule ElixirDnstap.Producer do
 
   @type t :: %__MODULE__{
           queue: :queue.queue(),
+          queue_len: non_neg_integer(),
           demand: non_neg_integer(),
           max_demand: pos_integer(),
           max_queue_size: pos_integer(),
@@ -106,10 +108,13 @@ defmodule ElixirDnstap.Producer do
   @impl true
   def init(opts) do
     max_demand = Keyword.get(opts, :max_demand, 100)
-    max_queue_size = Keyword.get(opts, :max_queue_size, @default_max_queue_size)
+
+    max_queue_size =
+      valid_max_queue_size(Keyword.get(opts, :max_queue_size, @default_max_queue_size))
 
     state = %__MODULE__{
       queue: :queue.new(),
+      queue_len: 0,
       demand: 0,
       max_demand: max_demand,
       max_queue_size: max_queue_size,
@@ -119,18 +124,33 @@ defmodule ElixirDnstap.Producer do
     {:producer, state}
   end
 
+  # A non-integer or non-positive max_queue_size would make the cap meaningless
+  # (e.g. `queue_len >= 0` drops everything), so fall back to the default.
+  defp valid_max_queue_size(size) when is_integer(size) and size > 0, do: size
+
+  defp valid_max_queue_size(invalid) do
+    Logger.warning(
+      "[DNSTap.Producer] invalid max_queue_size #{inspect(invalid)}; using #{@default_max_queue_size}"
+    )
+
+    @default_max_queue_size
+  end
+
   @impl true
   def handle_cast(message, state) when is_tuple(message) do
     Logger.debug(
-      "[DNSTap.Producer] Received message: #{inspect(elem(message, 0))}, current demand: #{state.demand}, queue size: #{:queue.len(state.queue)}"
+      "[DNSTap.Producer] Received message: #{inspect(elem(message, 0))}, current demand: #{state.demand}, queue size: #{state.queue_len}"
     )
 
-    if :queue.len(state.queue) >= state.max_queue_size do
+    if state.queue_len >= state.max_queue_size do
       # High-water mark reached: drop this message rather than grow the queue
-      # (and OOM) while the downstream writer is unable to keep up.
+      # (and OOM) while the downstream writer is unable to keep up. `queue_len`
+      # is tracked in the state so this hot-path check is O(1) (`:queue.len/1`
+      # is O(n)).
       {:noreply, [], count_drop(state)}
     else
-      dispatch_events(:queue.in(message, state.queue), state.demand, [], state)
+      queue = :queue.in(message, state.queue)
+      dispatch_events(queue, state.queue_len + 1, state.demand, [], state)
     end
   end
 
@@ -140,31 +160,32 @@ defmodule ElixirDnstap.Producer do
     new_demand = min(state.demand + incoming_demand, state.max_demand)
 
     Logger.debug(
-      "[DNSTap.Producer] Demand received: #{incoming_demand}, new total demand: #{new_demand}, queue size: #{:queue.len(state.queue)}"
+      "[DNSTap.Producer] Demand received: #{incoming_demand}, new total demand: #{new_demand}, queue size: #{state.queue_len}"
     )
 
-    dispatch_events(state.queue, new_demand, [], state)
+    dispatch_events(state.queue, state.queue_len, new_demand, [], state)
   end
 
   ## Private Functions
 
   # Dispatch queued events based on available demand, preserving the rest of the
-  # producer state (max_demand, max_queue_size, dropped).
-  @spec dispatch_events(:queue.queue(), non_neg_integer(), [message()], t()) ::
+  # producer state. `queue_len` is threaded (and decremented per dispatched
+  # event) so it stays exact without an O(n) `:queue.len/1` scan.
+  @spec dispatch_events(:queue.queue(), non_neg_integer(), non_neg_integer(), [message()], t()) ::
           {:noreply, [message()], t()}
-  defp dispatch_events(queue, demand, events, state) do
+  defp dispatch_events(queue, queue_len, demand, events, state) do
     case {demand, :queue.out(queue)} do
       # No demand left - stop dispatching
       {0, _} ->
-        {:noreply, Enum.reverse(events), %{state | queue: queue, demand: 0}}
+        {:noreply, Enum.reverse(events), %{state | queue: queue, queue_len: queue_len, demand: 0}}
 
       # Queue empty - accumulate demand
       {demand, {:empty, queue}} ->
-        {:noreply, Enum.reverse(events), %{state | queue: queue, demand: demand}}
+        {:noreply, Enum.reverse(events), %{state | queue: queue, queue_len: 0, demand: demand}}
 
       # Dispatch one event and continue
       {demand, {{:value, event}, queue}} ->
-        dispatch_events(queue, demand - 1, [event | events], state)
+        dispatch_events(queue, queue_len - 1, demand - 1, [event | events], state)
     end
   end
 

--- a/lib/elixir_dnstap/producer.ex
+++ b/lib/elixir_dnstap/producer.ex
@@ -17,6 +17,13 @@ defmodule ElixirDnstap.Producer do
   - Messages are dispatched immediately when demand exists
   - `max_demand` prevents unbounded demand accumulation
 
+  `GenStage.cast/2` is fire-and-forget, so a slow or disconnected downstream
+  writer cannot back-pressure the caller. To bound memory, the internal queue
+  has a `max_queue_size` high-water mark: once it is full, further messages are
+  **dropped** (tail drop) with a throttled counter/log rather than growing the
+  queue without limit. DNSTap is observability data, so dropping under overload
+  is preferable to OOMing the host.
+
   ## Usage
 
       # Start the producer
@@ -31,14 +38,24 @@ defmodule ElixirDnstap.Producer do
   use GenStage
   require Logger
 
+  # Default high-water mark for the internal queue.
+  @default_max_queue_size 10_000
+
+  # Emit at most one "dropped" warning per this many drops.
+  @drop_log_interval 1_000
+
   defstruct queue: :queue.new(),
             demand: 0,
-            max_demand: 100
+            max_demand: 100,
+            max_queue_size: @default_max_queue_size,
+            dropped: 0
 
   @type t :: %__MODULE__{
           queue: :queue.queue(),
           demand: non_neg_integer(),
-          max_demand: pos_integer()
+          max_demand: pos_integer(),
+          max_queue_size: pos_integer(),
+          dropped: non_neg_integer()
         }
 
   @type message_type :: :client_query | :client_response
@@ -89,11 +106,14 @@ defmodule ElixirDnstap.Producer do
   @impl true
   def init(opts) do
     max_demand = Keyword.get(opts, :max_demand, 100)
+    max_queue_size = Keyword.get(opts, :max_queue_size, @default_max_queue_size)
 
     state = %__MODULE__{
       queue: :queue.new(),
       demand: 0,
-      max_demand: max_demand
+      max_demand: max_demand,
+      max_queue_size: max_queue_size,
+      dropped: 0
     }
 
     {:producer, state}
@@ -105,7 +125,13 @@ defmodule ElixirDnstap.Producer do
       "[DNSTap.Producer] Received message: #{inspect(elem(message, 0))}, current demand: #{state.demand}, queue size: #{:queue.len(state.queue)}"
     )
 
-    dispatch_events(:queue.in(message, state.queue), state.demand, [], state.max_demand)
+    if :queue.len(state.queue) >= state.max_queue_size do
+      # High-water mark reached: drop this message rather than grow the queue
+      # (and OOM) while the downstream writer is unable to keep up.
+      {:noreply, [], count_drop(state)}
+    else
+      dispatch_events(:queue.in(message, state.queue), state.demand, [], state)
+    end
   end
 
   @impl true
@@ -117,29 +143,43 @@ defmodule ElixirDnstap.Producer do
       "[DNSTap.Producer] Demand received: #{incoming_demand}, new total demand: #{new_demand}, queue size: #{:queue.len(state.queue)}"
     )
 
-    dispatch_events(state.queue, new_demand, [], state.max_demand)
+    dispatch_events(state.queue, new_demand, [], state)
   end
 
   ## Private Functions
 
-  # Dispatch queued events based on available demand
-  @spec dispatch_events(:queue.queue(), non_neg_integer(), [message()], pos_integer()) ::
+  # Dispatch queued events based on available demand, preserving the rest of the
+  # producer state (max_demand, max_queue_size, dropped).
+  @spec dispatch_events(:queue.queue(), non_neg_integer(), [message()], t()) ::
           {:noreply, [message()], t()}
-  defp dispatch_events(queue, demand, events, max_demand) do
+  defp dispatch_events(queue, demand, events, state) do
     case {demand, :queue.out(queue)} do
       # No demand left - stop dispatching
       {0, _} ->
-        {:noreply, Enum.reverse(events),
-         %__MODULE__{queue: queue, demand: 0, max_demand: max_demand}}
+        {:noreply, Enum.reverse(events), %{state | queue: queue, demand: 0}}
 
       # Queue empty - accumulate demand
       {demand, {:empty, queue}} ->
-        {:noreply, Enum.reverse(events),
-         %__MODULE__{queue: queue, demand: demand, max_demand: max_demand}}
+        {:noreply, Enum.reverse(events), %{state | queue: queue, demand: demand}}
 
       # Dispatch one event and continue
       {demand, {{:value, event}, queue}} ->
-        dispatch_events(queue, demand - 1, [event | events], max_demand)
+        dispatch_events(queue, demand - 1, [event | events], state)
     end
+  end
+
+  # Count a dropped message, logging at a throttled rate to avoid amplifying a
+  # flood into a log storm.
+  @spec count_drop(t()) :: t()
+  defp count_drop(state) do
+    dropped = state.dropped + 1
+
+    if rem(dropped, @drop_log_interval) == 0 do
+      Logger.warning(
+        "[DNSTap.Producer] queue full (max_queue_size=#{state.max_queue_size}); dropped #{dropped} messages so far"
+      )
+    end
+
+    %{state | dropped: dropped}
   end
 end

--- a/test/elixir_dnstap/producer_test.exs
+++ b/test/elixir_dnstap/producer_test.exs
@@ -24,6 +24,14 @@ defmodule ElixirDnstap.ProducerTest do
     query_time_nsec: 123_456_789
   }
 
+  # Cast `n` client_query messages through handle_cast/2, threading the state.
+  defp cast_n(state, n) do
+    Enum.reduce(1..n, state, fn _, s ->
+      {:noreply, _events, s2} = Producer.handle_cast({:client_query, @test_query_params}, s)
+      s2
+    end)
+  end
+
   describe "init/1" do
     test "initializes with empty queue and zero demand" do
       assert {:producer, state} = Producer.init([])
@@ -184,6 +192,52 @@ defmodule ElixirDnstap.ProducerTest do
 
       # Total demand (13) should be capped at max_demand (10)
       assert state2.demand == 10
+    end
+  end
+
+  describe "queue high-water mark (D-3)" do
+    test "initializes with a configurable max_queue_size" do
+      assert {:producer, state} = Producer.init(max_queue_size: 5)
+      assert state.max_queue_size == 5
+    end
+
+    test "has a finite positive default max_queue_size" do
+      {:producer, state} = Producer.init([])
+      assert is_integer(state.max_queue_size) and state.max_queue_size > 0
+    end
+
+    test "drops messages instead of growing the queue past max_queue_size" do
+      {:producer, state} = Producer.init(max_queue_size: 3)
+
+      # No demand, so every message queues until the cap is reached.
+      state = cast_n(state, 3)
+      assert :queue.len(state.queue) == 3
+      assert state.dropped == 0
+
+      # Beyond the cap, messages are dropped (tail drop), not queued.
+      state = cast_n(state, 4)
+      assert :queue.len(state.queue) == 3
+      assert state.dropped == 4
+    end
+
+    test "resumes queuing after demand drains the buffer" do
+      {:producer, state} = Producer.init(max_queue_size: 2)
+
+      state = cast_n(state, 2)
+      # One drop while full.
+      state = cast_n(state, 1)
+      assert state.dropped == 1
+      assert :queue.len(state.queue) == 2
+
+      # Demand drains the queue...
+      {:noreply, events, state} = Producer.handle_demand(2, state)
+      assert length(events) == 2
+      assert :queue.is_empty(state.queue)
+
+      # ...so new messages are accepted again, not dropped.
+      state = cast_n(state, 1)
+      assert :queue.len(state.queue) == 1
+      assert state.dropped == 1
     end
   end
 

--- a/test/elixir_dnstap/producer_test.exs
+++ b/test/elixir_dnstap/producer_test.exs
@@ -206,6 +206,26 @@ defmodule ElixirDnstap.ProducerTest do
       assert is_integer(state.max_queue_size) and state.max_queue_size > 0
     end
 
+    test "falls back to the default max_queue_size on an invalid value" do
+      for bad <- [0, -1, "100", nil] do
+        {:producer, state} = Producer.init(max_queue_size: bad)
+        assert is_integer(state.max_queue_size) and state.max_queue_size > 0
+      end
+    end
+
+    test "keeps the tracked queue_len consistent with the actual queue" do
+      {:producer, state} = Producer.init(max_queue_size: 3)
+
+      # Fill past the cap, then drain with demand; queue_len must match at each step.
+      state = cast_n(state, 5)
+      assert state.queue_len == :queue.len(state.queue)
+      assert state.queue_len == 3
+
+      {:noreply, _events, state} = Producer.handle_demand(2, state)
+      assert state.queue_len == :queue.len(state.queue)
+      assert state.queue_len == 1
+    end
+
     test "drops messages instead of growing the queue past max_queue_size" do
       {:producer, state} = Producer.init(max_queue_size: 3)
 


### PR DESCRIPTION
Fixes #36.

## Problem

`ElixirDnstap.Producer.handle_cast/2` enqueued every message with `:queue.in` and only dispatched up to the current `demand`. `max_demand` caps *demand* accumulation but **not the queue length**, so when demand stays 0 — the downstream writer (file / TCP / unix socket) is slow, disconnected, or reconnecting — the queue grows without bound and OOMs the host. `GenStage.cast/2` (the `enqueue/2` path) is fire-and-forget, so the DNS worker calling it is never back-pressured. The moduledoc advertised "demand-based backpressure" but had no high-water mark or drop policy.

## Fix

- Add a configurable `max_queue_size` high-water mark (default 10_000).
- When the queue is at capacity, **drop** the incoming message (tail drop) with a throttled counter/log instead of enqueuing it.

DNSTap is observability data, so dropping under overload is preferable to OOMing the DNS server. Steady-state dispatch (demand available) is unchanged.

## Verification

New unit tests in `producer_test.exs`: configurable/default `max_queue_size`, drop-when-full (queue stays at the cap, `dropped` counts the excess), and resume-queuing after demand drains the buffer.

Verified end to end on a running producer: **20_000 casts into a cap-100 producer with no consumer leave the queue at 100 with 19_900 dropped** — bounded, no growth. Full suite green (115 tests, 3 doctests), `mix credo --strict` clean, `mix compile --warnings-as-errors` clean.

Found during an ecosystem security review (theme D-3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)